### PR TITLE
fix: slack_sdkのバージョンを上げてfiles_upload_v2が動かない問題を解決する

### DIFF
--- a/python/app/requirements.txt
+++ b/python/app/requirements.txt
@@ -2,7 +2,7 @@ matplotlib==3.3.2
 mysql-connector-python==8.0.22
 requests==2.25.0
 load_dotenv==0.1.0
-slack_sdk == 3.20.0
+slack_sdk == 3.20.1
 schedule == 1.1.0
 
 


### PR DESCRIPTION
https://github.com/slackapi/python-slack-sdk/issues/1342