### PR TITLE
Fix：ハッシュ値の先頭が0の場合ユーザ特定ができない問題の修正

### DIFF
--- a/go/app/controller/beacon.go
+++ b/go/app/controller/beacon.go
@@ -83,7 +83,7 @@ func getUserIdBySipHash(randomValue string, hashValue string) (int64, error) {
 
 			// 結果を出力
 			// 結果が一緒になればそのユーザの秘密キーがビーコン固有の秘密キー
-			if(hashValue == strconv.FormatUint(hash, 16)){
+			if(hashValue == fmt.Sprintf("%016x", hash)){
 				return int64(user.ID), nil
 			}
 		}


### PR DESCRIPTION
SipHashでハッシュ化する際先頭が0になる場合、省略されてしまう。それにより送られてくるUUIDに含まれるハッシュ値には先頭が0が付くものの、バックエンドでハッシュ化した値には先頭に0が付かない。これによりユーザが特定できなかった。