### PR TITLE
feat: バックアップファイル(~.tar.gz拡張子のファイル)の共有停止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ docker_rsa*
 
 
 __pycache__/
+
+# remove backup files
+*.tar.gz


### PR DESCRIPTION
## 修正内容
.gitignoreに*.tar.gzを追記した

## 修正結果
バックアップファイル(~.tar.gz拡張子のファイル)が追跡から外れた