### PR TITLE
feat: PrivBeaconに対応

### DIFF
--- a/go/app/controller/beacon.go
+++ b/go/app/controller/beacon.go
@@ -103,6 +103,9 @@ func convertBeaconsStayers(inputBeacons []*model.BeaconSignal) []model.Stayer {
 
 		userId := int64(0)
 		if strings.HasPrefix(inputBeacon.Msd, PRIVBEACON_MSD_PREFIX) {
+			if len(inputBeacon.Msd) < 20 {
+				continue
+			}
 			// PrivBeaconの場合
 			hashValue := inputBeacon.Msd[4:20]
 			randomValue := inputBeacon.Msd[20:]

--- a/go/app/controller/beacon.go
+++ b/go/app/controller/beacon.go
@@ -130,6 +130,9 @@ func convertBeaconsStayers(inputBeacons []*model.BeaconSignal) []model.Stayer {
 			userId = tmpUserId
 			if err != nil {
 				// もし見つからなかった場合基本的に旧滞在ウォッチビーコンである
+				if len(inputBeacon.Uuid) < 17 {
+					continue
+				}
 				randomValue := inputBeacon.Uuid[:16]
 				hashValue := inputBeacon.Uuid[16:]
 				tmpUserId, err := getUserIdBySipHash(randomValue, hashValue)

--- a/go/app/model/json.go
+++ b/go/app/model/json.go
@@ -146,6 +146,7 @@ type BeaconRoom struct {
 
 type BeaconSignal struct {
 	Uuid string `json:"uuid" form:"uuid"`
+	Msd  string `json:"msd"  form:"msd"`
 	Rssi int64  `json:"rssi" form:"rssi"`
 }
 
@@ -204,12 +205,12 @@ type ProbabilityResult struct {
 }
 
 type PredictionResponse struct {
-	Weekday   int                `json:"weekday"`
-	Result    []PredictionResult `json:"result"`
+	Weekday int                `json:"weekday"`
+	Result  []PredictionResult `json:"result"`
 }
 
 type PredictionResult struct {
-	UserID         int64   `json:"userId"`
+	UserID         int64  `json:"userId"`
 	PredictionTime string `json:"predictionTime"`
 }
 

--- a/test.http
+++ b/test.http
@@ -93,7 +93,8 @@ content-type: application/json
             "rssi": -49
         },
         {
-            "uuid": "8ebc21144abdba0db7c6ff0f0027ac00",
+            "uuid": "",
+            "msd": "ffff2fe318a70be1471fd4ed8976601f0431ed50f404",
             "rssi": -49
         }
     ],


### PR DESCRIPTION
## 概要
PrivBeaconに対応

## 詳細
- ラズパイ受信機からGoサーバへのリクエストの型にmsd(manufacuterer spacific data)を追加
- controllerのビーコン電波情報から滞在者情報を取得する関数(convertBeaconsStayers)にPrivBeaconの処理を追加

## TODO

## おしらせ
