### PR TITLE
fix: 受信機(ラズパイ)から送られてくるMSDの先頭がffffでない場合かつUUIDが空の場合の不具合の解消

### DIFF
--- a/go/app/controller/beacon.go
+++ b/go/app/controller/beacon.go
@@ -48,6 +48,7 @@ func getEndUUIDByManufacturer(manufacturer string) string {
 	return resultManufacturer
 }
 
+// ランダム値とハッシュ値からDBのユーザテーブル内のキーでフルテーブルスキャンする
 func getUserIdBySipHash(randomValue string, hashValue string) (int64, error) {
 	UserService := service.UserService{}
 	users, err := UserService.GetUsersByBeaconId(BEACON_ID_STAYWATCHBEACON)
@@ -101,8 +102,7 @@ func convertBeaconsStayers(inputBeacons []*model.BeaconSignal) []model.Stayer {
 
 	outStayers := []model.Stayer{}
 	for _, inputBeacon := range inputBeacons {
-
-		userId := int64(0)
+		// MSDを用いる場合とUUIDを用いる場合で分ける
 		// MSDを用いる場合（現在はPrivBeaconのみ）
 		if inputBeacon.Msd != "" {
 			// PrivBeaconはMSDの頭4文字が固定値かつMSDの長さが20文字より大きい
@@ -110,52 +110,46 @@ func convertBeaconsStayers(inputBeacons []*model.BeaconSignal) []model.Stayer {
 				// PrivBeaconの場合MSDからランダム値部分とハッシュ値部分を取り出して、DB内のPrivBeaconユーザを総当たりでハッシュ化しユーザ特定する
 				hashValue := inputBeacon.Msd[4:20]
 				randomValue := inputBeacon.Msd[20:]
-				tmpUserId, err := getUserIdBySipHash(randomValue, hashValue)
-				if err != nil {
-					fmt.Println("Error:", err)
+				privBeaconUserId, err := getUserIdBySipHash(randomValue, hashValue)
+				if err == nil {
+					// 見つかったら滞在者リストに追加して次のforへ
+					outStayers = append(outStayers, model.Stayer{
+						UserID: privBeaconUserId,
+						Rssi:   inputBeacon.Rssi,
+					})
 					continue
 				}
-				userId = tmpUserId
 			}
-		} else if len(inputBeacon.Uuid) == 38 {
-			// iPhoneビーコンの場合UUIDを取得する処理が必要(例："4c000180000021000021000021000021000021" -> "8ebc21144abd00000000ff0100000021")
-			tmpUUID := getEndUUIDByManufacturer(inputBeacon.Uuid)
-			uuid := "8ebc21144abd00000000ff01000" + tmpUUID
-			tmpUserId, err := UserService.GetUserIDByUUID(uuid)
-			if err != nil {
-				fmt.Println("Cannot get userid by uuid:", err)
+		}
+		// UUIDを用いる場合（iPhoneBeaconやAndroidビーコン、市販ビーコンなど）
+		if inputBeacon.Uuid != "" {
+			// iPhoneビーコンは送られてくるUUID情報を含む値の長さが38文字
+			if len(inputBeacon.Uuid) == 38 {
+				// iPhoneビーコンの場合UUIDを取得する処理が必要(例："4c000180000021000021000021000021000021" -> "8ebc21144abd00000000ff0100000021")
+				tmpUUID := getEndUUIDByManufacturer(inputBeacon.Uuid)
+				uuid := "8ebc21144abd00000000ff01000" + tmpUUID
+				iphoneUserId, err := UserService.GetUserIDByUUID(uuid)
+				if err == nil {
+					// 見つかったら滞在者リストに追加して次のforへ
+					outStayers = append(outStayers, model.Stayer{
+						UserID: iphoneUserId,
+						Rssi:   inputBeacon.Rssi,
+					})
+					continue
+				}
+			}
+			// Androidビーコンや市販ビーコンの場合は単純にUUIDからユーザを検索
+			commonBeaconUserId, err := UserService.GetUserIDByUUID(inputBeacon.Uuid)
+			if err == nil {
+				// 見つかったら滞在者リストに追加して次のforへ
+				outStayers = append(outStayers, model.Stayer{
+					UserID: commonBeaconUserId,
+					Rssi:   inputBeacon.Rssi,
+				})
 				continue
 			}
-			userId = tmpUserId
-		} else {
-			tmpUserId, err := UserService.GetUserIDByUUID(inputBeacon.Uuid)
-			userId = tmpUserId
-			if err != nil {
-				// もし見つからなかった場合基本的に旧滞在ウォッチビーコンである
-				if len(inputBeacon.Uuid) < 17 {
-					continue
-				}
-				randomValue := inputBeacon.Uuid[:16]
-				hashValue := inputBeacon.Uuid[16:]
-				tmpUserId, err := getUserIdBySipHash(randomValue, hashValue)
-				if err != nil {
-					fmt.Println("Error:", err)
-					continue
-				}
-				userId = tmpUserId
-			}
-		}
-
-		// 0でない(ユーザが見つかった場合)のみ追加
-		if userId != 0 {
-			tmpStayer := model.Stayer{
-				UserID: userId,
-				Rssi:   inputBeacon.Rssi,
-			}
-			outStayers = append(outStayers, tmpStayer)
 		}
 	}
-
 	return outStayers
 }
 


### PR DESCRIPTION
## 概要
受信機(ラズパイ)から送られてくるMSDの先頭がffffでない場合かつUUIDが空の場合だと、DB内のUUIDが""であるユーザがヒットしてしまい誤動作が起きてしまっていた。それの解消。

## 詳細
受信機(ラズパイ)から送られてくる電波情報からユーザを検索する関数での、どのビーコンか(AndroidビーコンかPrivBeaconか市販ビーコンかなど)を分ける場合わけの書き方を適切にした。

## TODO

## おしらせ
