### PR TITLE
Fix/computational errors

### DIFF
--- a/go/app/service/room.go
+++ b/go/app/service/room.go
@@ -416,7 +416,7 @@ func (RoomService) GetWeeksSinceFirstLog(userId int64) (int, error) {
 	defer closer.Close()
 	var weeks int
 	result := DbEngine.Raw(`
-		SELECT TIMESTAMPDIFF(WEEK, MIN(start_at), NOW())
+		SELECT TIMESTAMPDIFF(WEEK, DATE(MIN(start_at)), CURDATE()) + 1
 		FROM logs
 		WHERE user_id = ?
 	`, userId).Scan(&weeks)

--- a/prediction/app/api/service/clustering.py
+++ b/prediction/app/api/service/clustering.py
@@ -9,6 +9,8 @@ def clustering(data: list[int]) -> list[ClusteringResult]:
     bic_values = []
     max_clusters = 4
     for n_clusters in range(1, max_clusters + 1):
+        if n_clusters > len(d):
+            break
         gmm = GaussianMixture(n_components=n_clusters, init_params="k-means++")
         gmm.fit(d.reshape(-1, 1))
         bic_values.append(gmm.bic(d.reshape(-1, 1)))


### PR DESCRIPTION
## 修正内容

予測APIで `id = 104` の時に0値になる問題の修正
予測APIで `id = 109` の時に100%を突破する問題の修正

## 修正結果

## TODO

## おしらせ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 週数の計算方法を修正し、ユーザーの最初のログ記録から現在までの週数がより正確に表示されるようになりました。
  - クラスタリング機能で、データ数より多いクラスタ数を指定した場合にエラーが発生しないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->