### PR TITLE
Feature:APIを叩く際にOAuth認証またはAPIキーが必要なようにした

### DIFF
--- a/go/app/main.go
+++ b/go/app/main.go
@@ -37,7 +37,8 @@ func SetUpServer() *gin.Engine {
 		AllowCredentials: true,
 		MaxAge:           24 * time.Hour,
 	}))
-	// 独自のリクエストタイマーをミドルウェアとして追加
+
+	// トークンの検証やAPIキーの検証
 	engine.Use(middleware.AuthCheck())
 
 	versionEngine := engine.Group("api/v1")

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -38,8 +38,7 @@ func SetUpServer() *gin.Engine {
 		MaxAge:           24 * time.Hour,
 	}))
 	// 独自のリクエストタイマーをミドルウェアとして追加
-	engine.Use(middleware.RequestTimer())
-	engine.Use(middleware.LoginCheck())
+	engine.Use(middleware.AuthCheck())
 
 	versionEngine := engine.Group("api/v1")
 	{

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	controller "Stay_watch/controller"
+	"Stay_watch/middleware"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -36,6 +37,9 @@ func SetUpServer() *gin.Engine {
 		AllowCredentials: true,
 		MaxAge:           24 * time.Hour,
 	}))
+	// 独自のリクエストタイマーをミドルウェアとして追加
+	engine.Use(middleware.RequestTimer())
+	engine.Use(middleware.LoginCheck())
 
 	versionEngine := engine.Group("api/v1")
 	{

--- a/go/app/middleware/auth.go
+++ b/go/app/middleware/auth.go
@@ -2,85 +2,89 @@ package middleware
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log"
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	firebase "firebase.google.com/go"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/api/option"
 )
 
-// RequestTimer は各リクエストの処理時間をログに出力するミドルウェアだ
-func RequestTimer() gin.HandlerFunc {
+func AuthCheck() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		startTime := time.Now()
-		c.Next() // 次のハンドラーへ処理を移す
-		duration := time.Since(startTime)
-		log.Printf("リクエスト %s %s の処理時間: %v", c.Request.Method, c.Request.RequestURI, duration)
-	}
-}
-
-func LoginCheck() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Firebase App 初期化
-		ctx := context.Background()
-		opt := option.WithCredentialsFile("./credentials/firebase.json")
-		if os.Getenv("ENVIRONMENT") == "production" {
-			opt = option.WithCredentialsFile("/app/credentials/firebase.json")
-		}
-
-		conf := &firebase.Config{ProjectID: "stay-watch-a616f"}
-		// OAuth2.0更新トークン対応用
-		app, err := firebase.NewApp(ctx, conf, opt)
-		// OAuth2.0を用いない場合はconfをnilにする
-		if err != nil {
-			fmt.Printf("Cannot initialize firebase app: %v\n", err)
-		}
-		authClient, err := app.Auth(ctx)
-		if err != nil {
-			log.Printf("Cannot initialize firebase auth: %v\n", err)
-			log.Println("認証失敗3")
-			c.Status(http.StatusUnauthorized)
-		}
-
-		// Authorization ヘッダー取得
-		authHeader := c.GetHeader("Authorization") // クライアントからJWTを取得する
+		// ヘッダー取得
+		authHeader := c.GetHeader("Authorization") // クライアントからAuthorizationを取得
 		tokenID := strings.Replace(authHeader, "Bearer ", "", 1)
-		if tokenID == "" {
-			c.Status(http.StatusUnauthorized)
+		apiKey := c.GetHeader("X-API-Key") // クライアントからAPIキーを取得
+
+		// トークンIDとAPIキーが両方空の場合は拒否する
+		if tokenID == "" && apiKey == "" {
+			log.Printf("Authorization and X-API-Key are empty")
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
 		}
 
-		// IDトークンの検証(JWTのベリファイ)
-		token, err := authClient.VerifyIDToken(ctx, tokenID)
-		if err != nil {
-			log.Printf("Token verify failed: %v\n", err)
-			log.Println("認証失敗2")
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+		// トークンIDかAPIキーどちらかが正しければリクエストを受理する
+		if tokenID != "" {
+			// トークンIDの検証
+			err := checkFirebaseAuth(tokenID)
+			if err != nil {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+		} else if apiKey != "" {
+			// APIキーの検証
+			err := checkAPIKey(apiKey)
+			if err != nil {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
 		}
-
-		uid := token.UID // 認証に成功した場合はuidを取得する
-		user, err := authClient.GetUser(ctx, uid)
-		if err != nil {
-			log.Printf("Cannot get user: %v\n", err)
-			log.Println("認証失敗1")
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "User fetch failed"})
-		}
-
-		// コンテキストに埋め込む
-		c.Set("user", map[string]string{
-			"Name":            user.DisplayName,
-			"ProfileImageURL": user.PhotoURL,
-			"FirebaseUID":     uid,
-			"Email":           user.Email,
-		})
-
-		log.Println("認証成功")
-		// log.Println(user.DisplayName, user.PhotoURL, user.Email)
 
 		c.Next()
 	}
+}
+
+func checkFirebaseAuth(tokenID string) error {
+	// Firebase App 初期化
+	ctx := context.Background()
+	opt := option.WithCredentialsFile("./credentials/firebase.json")
+	if os.Getenv("ENVIRONMENT") == "production" {
+		opt = option.WithCredentialsFile("/app/credentials/firebase.json")
+	}
+
+	conf := &firebase.Config{ProjectID: "stay-watch-a616f"}
+	// OAuth2.0更新トークン対応用
+	app, err := firebase.NewApp(ctx, conf, opt)
+	// OAuth2.0を用いない場合はconfをnilにする
+	if err != nil {
+		log.Printf("Cannot initialize firebase app: %v\n", err)
+		return err
+	}
+	authClient, err := app.Auth(ctx)
+	if err != nil {
+		log.Printf("Cannot initialize firebase auth: %v\n", err)
+		return err
+	}
+
+	// IDトークンの検証(JWTのベリファイ)
+	_, err = authClient.VerifyIDToken(ctx, tokenID)
+	if err != nil {
+		log.Printf("Token verify failed: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func checkAPIKey(apiKey string) error {
+	if apiKey != "abcde1" {
+		err := errors.New("invalid API Key")
+		log.Printf("%v", err)
+		return err
+	}
+	return nil
 }

--- a/go/app/middleware/auth.go
+++ b/go/app/middleware/auth.go
@@ -81,7 +81,7 @@ func checkFirebaseAuth(tokenID string) error {
 }
 
 func checkAPIKey(apiKey string) error {
-	if apiKey != "abcde1" {
+	if apiKey != os.Getenv("STAYWATCH_API_KEY") {
 		err := errors.New("invalid API Key")
 		log.Printf("%v", err)
 		return err

--- a/go/app/middleware/auth.go
+++ b/go/app/middleware/auth.go
@@ -1,3 +1,4 @@
+// Package middleware provides middleware handlers for authentication and other HTTP middleware features.
 package middleware
 
 import (

--- a/go/app/middleware/auth.go
+++ b/go/app/middleware/auth.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	firebase "firebase.google.com/go"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/api/option"
+)
+
+// RequestTimer は各リクエストの処理時間をログに出力するミドルウェアだ
+func RequestTimer() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		startTime := time.Now()
+		c.Next() // 次のハンドラーへ処理を移す
+		duration := time.Since(startTime)
+		log.Printf("リクエスト %s %s の処理時間: %v", c.Request.Method, c.Request.RequestURI, duration)
+	}
+}
+
+func LoginCheck() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Firebase App 初期化
+		ctx := context.Background()
+		opt := option.WithCredentialsFile("./credentials/firebase.json")
+		if os.Getenv("ENVIRONMENT") == "production" {
+			opt = option.WithCredentialsFile("/app/credentials/firebase.json")
+		}
+
+		conf := &firebase.Config{ProjectID: "stay-watch-a616f"}
+		// OAuth2.0更新トークン対応用
+		app, err := firebase.NewApp(ctx, conf, opt)
+		// OAuth2.0を用いない場合はconfをnilにする
+		if err != nil {
+			fmt.Printf("Cannot initialize firebase app: %v\n", err)
+		}
+		authClient, err := app.Auth(ctx)
+		if err != nil {
+			log.Printf("Cannot initialize firebase auth: %v\n", err)
+			log.Println("認証失敗3")
+			c.Status(http.StatusUnauthorized)
+		}
+
+		// Authorization ヘッダー取得
+		authHeader := c.GetHeader("Authorization") // クライアントからJWTを取得する
+		tokenID := strings.Replace(authHeader, "Bearer ", "", 1)
+		if tokenID == "" {
+			c.Status(http.StatusUnauthorized)
+		}
+
+		// IDトークンの検証(JWTのベリファイ)
+		token, err := authClient.VerifyIDToken(ctx, tokenID)
+		if err != nil {
+			log.Printf("Token verify failed: %v\n", err)
+			log.Println("認証失敗2")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+		}
+
+		uid := token.UID // 認証に成功した場合はuidを取得する
+		user, err := authClient.GetUser(ctx, uid)
+		if err != nil {
+			log.Printf("Cannot get user: %v\n", err)
+			log.Println("認証失敗1")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "User fetch failed"})
+		}
+
+		// コンテキストに埋め込む
+		c.Set("user", map[string]string{
+			"Name":            user.DisplayName,
+			"ProfileImageURL": user.PhotoURL,
+			"FirebaseUID":     uid,
+			"Email":           user.Email,
+		})
+
+		log.Println("認証成功")
+		// log.Println(user.DisplayName, user.PhotoURL, user.Email)
+
+		c.Next()
+	}
+}


### PR DESCRIPTION
## 概要
APIを叩く際にOAuth認証またはAPIキーが必要なようにした

## 詳細
OAuth認証はFirebaseAuthenticationを用いて、APIキーは.envファイルで管理してBasic認証。
APIのルーティングに行く前に実行されるmiddleware層にこれを追加。
