### PR TITLE
Fix: 登録がないPrivBeaconがある場合削除済みユーザが滞在登録されてしまうのを修正

### DIFF
--- a/go/app/controller/beacon.go
+++ b/go/app/controller/beacon.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -93,7 +94,7 @@ func getUserIdBySipHash(randomValue string, hashValue string) (int64, error) {
 	}
 
 	// 見つからなかった場合エラーを返す
-	return 0, err
+	return 0, errors.New("no matching user found")
 }
 
 // ラズパイ受信機から送られてきた電波情報からユーザを特定


### PR DESCRIPTION
## 修正概要
登録がないPrivBeaconがある場合削除済みユーザが滞在登録されてしまうのを修正

## 詳細
PrivBeaconのMSDをユーザテーブルと照らし合わせて見つからない場合errを返す関数にてerrを返していなかったのが原因。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 不具合修正
  - ユーザーが見つからないケースで確実にエラーを返すよう改善し、想定外の成功扱いや後続処理の不整合を防止しました。
  - エラーの一貫したハンドリングとメッセージ明確化により、異常時の挙動がより予測可能になり、信頼性と運用性（ログ/監視）の向上につながります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->