### PR TITLE
Fix：ユーザ情報更新時に元のPrivBeacon持ち主のキーが空文字にならないのを修正

### DIFF
--- a/go/app/controller/user.go
+++ b/go/app/controller/user.go
@@ -315,7 +315,6 @@ func UpdateUser(c *gin.Context) {
 	}
 
 	// 値が存在するフィールドのみ更新
-	user.Name = UserUpdateRequest.Name
 	// nilでない場合のみ更新
 	if UserUpdateRequest.Email != nil {
 		user.Email = *UserUpdateRequest.Email
@@ -325,6 +324,9 @@ func UpdateUser(c *gin.Context) {
 	}
 	if UserUpdateRequest.CommunityId != nil {
 		user.CommunityId = *UserUpdateRequest.CommunityId
+	}
+	if UserUpdateRequest.Name != "" {
+		user.Name = UserUpdateRequest.Name
 	}
 
 	// usersテーブルにユーザ情報を保存

--- a/go/app/service/user.go
+++ b/go/app/service/user.go
@@ -525,7 +525,7 @@ func (UserService) UpdateUserWithPrivBeacon(reqUser model.User) (model.User, err
 	err = DBEngine.Transaction(func(tx *gorm.DB) error {
 		// privateKey==""のとき一括更新されないようにする
 		if reqUser.PrivateKey != "" {
-			// リクエストのPrivateKeyのカラムを空文字にする
+			// 元の持ち主のPrivateKeyカラムを空文字にする
 			result := tx.Model(&model.User{}).Where("private_key = ?", reqUser.PrivateKey).
 				Updates(map[string]interface{}{
 					"private_key": "",
@@ -537,9 +537,18 @@ func (UserService) UpdateUserWithPrivBeacon(reqUser model.User) (model.User, err
 			}
 		}
 
-		// ユーザ更新
-		result := tx.Model(&model.User{}).Where("id = ?", reqUser.ID).Updates(&reqUser).Update("private_key", reqUser.PrivateKey) // PrvateKeyだけは空文字でも更新されてほしいため
-		// result = tx.Create(&reqUser)
+		// 次の持ち主のユーザ更新
+		result := tx.Model(&model.User{}).
+			Where("id = ?", reqUser.ID).
+			Updates(map[string]interface{}{
+				"uuid":         reqUser.UUID,
+				"name":         reqUser.Name,
+				"email":        reqUser.Email,
+				"role":         reqUser.Role,
+				"private_key":  reqUser.PrivateKey,
+				"beacon_id":    reqUser.BeaconId,
+				"community_id": reqUser.CommunityId,
+			})
 		if result.Error != nil {
 			fmt.Println(result.Error)
 			return result.Error

--- a/mysql/script/init.sh
+++ b/mysql/script/init.sh
@@ -1,2 +1,2 @@
 /usr/sbin/sshd
-mysqld
+exec docker-entrypoint.sh mysqld


### PR DESCRIPTION
## 修正内容
PUT /api/v1/users の修正

## 修正結果

## TODO

## おしらせ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユーザー名が空の値で上書きされることを防止
  * ユーザー認証情報更新時に、前のオーナーのプライベートキーとビーコンIDを適切にクリアするように改善

* **インフラストラクチャ**
  * Docker起動プロセスの処理を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->